### PR TITLE
Select 페이지 레이아웃

### DIFF
--- a/pages/select/index.tsx
+++ b/pages/select/index.tsx
@@ -1,0 +1,89 @@
+import styled from '@emotion/styled';
+import FirstPage from '@src/components/select/FirstPage';
+import SecondPage from '@src/components/select/SecondPage';
+import { useRouter } from 'next/router';
+import React, { useState } from 'react';
+
+interface ISelect {
+  first: number;
+  second: number;
+  third: number;
+  fourth: number;
+  fifth: number;
+  sixth: number;
+  seventh: number;
+}
+
+const Select = () => {
+  const router = useRouter();
+
+  const [pageIdx, setPageIdx] = useState<number>(1);
+
+  const [selectedInfo, setSelectedInfo] = useState<ISelect>({
+    first: 0,
+    second: 0,
+    third: 0,
+    fourth: 0,
+    fifth: 0,
+    sixth: 0,
+    seventh: 0,
+  });
+
+  console.log(selectedInfo.first);
+
+  const pages = [<FirstPage key={0} />, <SecondPage key={1} />];
+
+  const isValid = !Object.values(selectedInfo).includes(0);
+
+  return (
+    <StSelect>
+      <StHeader>가장 나다운 말을 선택해주세요</StHeader>
+      <StBody>{pages[pageIdx]}</StBody>
+      {pageIdx === 1 && (
+        <StFooter>
+          <StNextBtn isValid={isValid}>결과보기</StNextBtn>
+        </StFooter>
+      )}
+    </StSelect>
+  );
+};
+
+const StSelect = styled.div`
+  padding: 20px;
+  padding-top: 30px;
+  width: 100%;
+  height: 100vh;
+  background: ${({ theme }) => theme.color.backgroundColor};
+`;
+
+const StHeader = styled.p`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 50px;
+  color: ${({ theme }) => theme.color.gray600};
+  font-size: 16px;
+`;
+
+const StBody = styled.div``;
+
+const StFooter = styled.div`
+  margin-top: 30px;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const StNextBtn = styled.button<{ isValid: boolean }>`
+  width: 271px;
+  height: 60px;
+  background: ${({ theme, isValid }) => (isValid ? theme.color.mainColor : theme.color.disabledColor)};
+  border-radius: 8px;
+  font-size: 20px;
+  font-weight: 600;
+  color: ${({ theme }) => theme.color.backgroundColor};
+  cursor: pointer;
+`;
+
+export default Select;

--- a/src/components/select/FirstPage.tsx
+++ b/src/components/select/FirstPage.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const FirstPage = () => {
+  return <div>첫번째 페이지</div>;
+};
+
+export default FirstPage;

--- a/src/components/select/SecondPage.tsx
+++ b/src/components/select/SecondPage.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const SecondPage = () => {
+  return <div>두번째 페이지</div>;
+};
+
+export default SecondPage;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,7 @@
 interface Color {
   mainColor: string;
   subColor: string;
+  disabledColor: string;
   backgroundColor: string;
   whiteColor: string;
   blackColor: string;

--- a/styles/global.tsx
+++ b/styles/global.tsx
@@ -20,6 +20,8 @@ const global = css`
   input,
   button {
     outline: none;
+    border: none;
+    cursor: pointer;
   }
 
   body,

--- a/styles/theme.tsx
+++ b/styles/theme.tsx
@@ -3,6 +3,7 @@ import { Theme } from '@emotion/react';
 const color = {
   mainColor: '#84F5B8',
   subColor: '#ABC2A7',
+  disabledColor: '#8A8B91',
   backgroundColor: '#1E2029',
   whiteColor: '#fff',
   blackColor: '#000',
@@ -21,6 +22,7 @@ const theme: Theme = {
     backgroundColor: color.backgroundColor,
     whiteColor: color.whiteColor,
     blackColor: color.blackColor,
+    disabledColor: color.disabledColor,
     gray500: color.gray500,
     gray600: color.gray600,
     gray700: color.gray700,


### PR DESCRIPTION
## :: 📌 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 🚩 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- Select 페이지 레이아웃

<br />

## :: 🧾 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. Select 페이지 레이아웃
- pages 라는 배열에 컴포넌트를 저장 후 pageIdx에 따라 컴포넌트가 전환될 수 있도록 구현
- 결과를 확인할 수 있는 StNextBtn은 마지막 페이지에서만 존재하기 때문에 pageIdx가 1일 경우에만(마지막 페이지) 보여지도록 &&연산자를 통해 구현
- StNextBtn은  isValid를 인자로 받고 모든 질문지들이 선택되었는지를 확인 후 true 또는 false를 반환하고 true일 경우 활성화
- isValid의 활성화(true)의 기준은 selectedInfo의 객체 안에 0이 있는지 없는지를 기준으로 true 또는 false를 반환