### PR TITLE
ADD : Second page 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.env
 
 # vercel
 .vercel

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/react-dom": "18.0.10",
     "axios": "^1.2.1",
     "babel-plugin-styled-components": "^2.0.7",
+    "dotenv": "^16.0.3",
     "eslint": "^8.30.0",
     "eslint-config-next": "13.1.1",
     "next": "13.1.1",

--- a/pages/select/index.tsx
+++ b/pages/select/index.tsx
@@ -1,20 +1,43 @@
 import React, { useState } from 'react';
 import styled from '@emotion/styled';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { selectedState } from '@src/store/selectedState';
 import FirstPage from '@src/components/select/FirstPage';
 import SecondPage from '@src/components/select/SecondPage';
+import usePostSelected from '@src/hooks/mutation/usePostSelected';
+import client, { baseURL } from '@src/api/client';
+import { useMutation } from 'react-query';
+import SelectAPI from '@src/api/select';
+import { AxiosResponse } from 'axios';
+import { useRouter } from 'next/router';
+import { locationState } from '@src/store/locationState';
 
 const Select = () => {
+  const router = useRouter();
+
+  const setLocationState = useSetRecoilState(locationState);
+
   const selectedInfo = useRecoilValue<ISelect>(selectedState);
 
   const [pageIdx, setPageIdx] = useState<number>(0);
 
   const selectedValues = Object.values(selectedInfo);
 
+  const { mutate: postSelectedMutate } = useMutation((data: ISelect) => SelectAPI.postSelected(data), {
+    onSuccess: (data: AxiosResponse) => {
+      setLocationState(data as any);
+      router.push('/loading');
+    },
+  });
+
   const pages = [
     <FirstPage key={0} selectedValues={selectedValues} setPageIdx={setPageIdx} />,
-    <SecondPage key={1} selectedValues={selectedValues} />,
+    <SecondPage
+      key={1}
+      selectedInfo={selectedInfo}
+      selectedValues={selectedValues}
+      postSelectedMutate={postSelectedMutate}
+    />,
   ];
 
   return (

--- a/pages/select/index.tsx
+++ b/pages/select/index.tsx
@@ -12,7 +12,10 @@ const Select = () => {
 
   const selectedValues = Object.values(selectedInfo);
 
-  const pages = [<FirstPage key={0} selectedValues={selectedValues} setPageIdx={setPageIdx} />, <SecondPage key={1} />];
+  const pages = [
+    <FirstPage key={0} selectedValues={selectedValues} setPageIdx={setPageIdx} />,
+    <SecondPage key={1} selectedValues={selectedValues} />,
+  ];
 
   return (
     <StSelect>
@@ -23,6 +26,7 @@ const Select = () => {
 };
 
 const StSelect = styled.div`
+  position: relative;
   padding: 0 20px;
   padding-top: 20px;
   width: 100%;

--- a/src/api/Sample.tsx
+++ b/src/api/Sample.tsx
@@ -1,8 +1,0 @@
-//하단 코드 지우고 작성 시작
-import React from 'react';
-
-const Sample = () => {
-  return <div></div>;
-};
-
-export default Sample;

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,0 +1,5 @@
+const API = {
+  postSelected: '/coasts',
+};
+
+export default API;

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,0 +1,19 @@
+import axios, { AxiosResponse } from 'axios';
+
+export const baseURL: string = process.env.NEXT_PUBLIC_BASE_URL as string;
+
+const client = axios.create({ baseURL });
+
+client.interceptors.response.use((res: AxiosResponse) => {
+  try {
+    if (res.status === 200) {
+      return res.data.data;
+    } else {
+      return [res.data.code, res.data.message];
+    }
+  } catch (e: any) {
+    return [true, e.message];
+  }
+});
+
+export default client;

--- a/src/api/select.ts
+++ b/src/api/select.ts
@@ -1,0 +1,10 @@
+import API from './api';
+import client from './client';
+
+const SelectAPI = {
+  postSelected: (data: ISelect) => {
+    return client.post(`${API.postSelected}`, data);
+  },
+};
+
+export default SelectAPI;

--- a/src/components/common/Question.tsx
+++ b/src/components/common/Question.tsx
@@ -15,7 +15,7 @@ const Question = ({ title, button, state }: IProps) => {
   const buttonHandler = (state: string, key: number) => {
     setSelectedInfo({ ...selectedInfo, [state]: key });
   };
-  console.log(selectedInfo[state]);
+
   return (
     <StQuestion>
       <StHeader>{title}</StHeader>

--- a/src/components/select/SecondPage.tsx
+++ b/src/components/select/SecondPage.tsx
@@ -3,10 +3,12 @@ import { SECOND_QUESTION } from '@src/mocks/SECOND_QUESTIONS';
 import Question from '../common/Question';
 
 interface IProps {
+  selectedInfo: ISelect;
   selectedValues: number[];
+  postSelectedMutate: any;
 }
 
-const SecondPage = ({ selectedValues }: IProps) => {
+const SecondPage = ({ selectedInfo, selectedValues, postSelectedMutate }: IProps) => {
   const hasValue = (key: number) => {
     return selectedValues[key] !== 0;
   };
@@ -21,7 +23,13 @@ const SecondPage = ({ selectedValues }: IProps) => {
         ))}
       </StBody>
       <StFooter>
-        <StButton canSubmit={canSubmit}>결과 보기</StButton>
+        <StButton
+          onClick={() => {
+            postSelectedMutate(selectedInfo);
+          }}
+          canSubmit={canSubmit}>
+          결과 보기
+        </StButton>
       </StFooter>
     </StSecondPage>
   );

--- a/src/components/select/SecondPage.tsx
+++ b/src/components/select/SecondPage.tsx
@@ -1,7 +1,61 @@
-import React from 'react';
+import styled from '@emotion/styled';
+import { SECOND_QUESTION } from '@src/mocks/SECOND_QUESTIONS';
+import Question from '../common/Question';
 
-const SecondPage = () => {
-  return <div>두번째 페이지</div>;
+interface IProps {
+  selectedValues: number[];
+}
+
+const SecondPage = ({ selectedValues }: IProps) => {
+  const hasValue = (key: number) => {
+    return selectedValues[key] !== 0;
+  };
+
+  const canSubmit = !selectedValues.includes(0);
+
+  return (
+    <StSecondPage>
+      <StBody>
+        {SECOND_QUESTION.map(({ id, state, title, button }) => (
+          <div key={id}>{hasValue(id - 1) && <Question state={state} title={title} button={button} />}</div>
+        ))}
+      </StBody>
+      <StFooter>
+        <StButton canSubmit={canSubmit}>결과 보기</StButton>
+      </StFooter>
+    </StSecondPage>
+  );
 };
+
+const StSecondPage = styled.div`
+  width: 100%;
+`;
+
+const StBody = styled.div`
+  width: 100%;
+`;
+
+const StFooter = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 30px;
+  width: 100%;
+`;
+
+const StButton = styled.button<{ canSubmit: boolean }>`
+  position: absolute;
+  left: 50%;
+  bottom: 1%;
+  transform: translate(-50%, -50%);
+  width: 271px;
+  height: 60px;
+  color: ${({ theme }) => theme.color.backgroundColor};
+  background: ${({ theme, canSubmit }) => (canSubmit ? theme.color.mainColor : theme.color.disabledColor)};
+  border-radius: 8px;
+  font-size: 20px;
+  font-weight: 600;
+  cursor: pointer;
+`;
 
 export default SecondPage;

--- a/src/hooks/Sample.tsx
+++ b/src/hooks/Sample.tsx
@@ -1,8 +1,0 @@
-//하단 코드 지우고 작성 시작
-import React from 'react';
-
-const Sample = () => {
-  return <div></div>;
-};
-
-export default Sample;

--- a/src/hooks/mutation/usePostSelected.ts
+++ b/src/hooks/mutation/usePostSelected.ts
@@ -1,0 +1,17 @@
+import SelectAPI from '@src/api/select';
+import { AxiosResponse } from 'axios';
+import { useRouter } from 'next/router';
+import { useMutation } from 'react-query';
+
+const usePostSelected = () => {
+  const router = useRouter();
+
+  return useMutation((data: ISelect) => SelectAPI.postSelected(data), {
+    onSuccess: (data: AxiosResponse) => {
+      router.push('/');
+      console.log(data);
+    },
+  });
+};
+
+export default usePostSelected;

--- a/src/mocks/SECOND_QUESTIONS.ts
+++ b/src/mocks/SECOND_QUESTIONS.ts
@@ -1,0 +1,39 @@
+export const SECOND_QUESTION: Question[] = [
+  {
+    id: 0,
+    state: 'fifth',
+    title: '내일 전 이걸 볼래요.',
+    button: [
+      { key: 1, option: '해 뜨는 거' },
+      { key: 2, option: '야경' },
+      { key: 3, option: '비 오는 거리' },
+      { key: 4, option: '노을' },
+      { key: 5, option: '영화/드라마' },
+      { key: 6, option: '전시회' },
+    ],
+  },
+  {
+    id: 1,
+    state: 'sixth',
+    title: '인생에서 이건 꼭 한번 해보고 싶어요.',
+    button: [
+      { key: 1, option: '유람선 타기' },
+      { key: 2, option: '오토바이 운전' },
+      { key: 3, option: '폭포아래서 명상' },
+      { key: 4, option: '고래 보기' },
+    ],
+  },
+  {
+    id: 2,
+    state: 'seventh',
+    title: '저는 이런 사람인 것 같아요.',
+    button: [
+      { key: 1, option: '친절한' },
+      { key: 2, option: '소박한' },
+      { key: 3, option: '트랜디한' },
+      { key: 4, option: '화려한' },
+      { key: 5, option: '느긋한' },
+      { key: 6, option: '마이웨이' },
+    ],
+  },
+];

--- a/src/store/locationState.ts
+++ b/src/store/locationState.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const locationState = atom<string>({
+  key: 'locationState',
+  default: '',
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2072,6 +2072,11 @@ domutils@^2.8.0:
     domelementtype "^2.2.0"
     domhandler "^4.2.0"
 
+dotenv@^16.0.3:
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
+  integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
+
 electron-to-chromium@^1.4.251:
   version "1.4.284"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz#61046d1e4cab3a25238f6bf7413795270f125592"


### PR DESCRIPTION
## :: 📌 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 🚩 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- Second page 구현

<br />

## :: 🧾 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. Second page 구현
- 기본적인 구현 사항은 first page와 동일
- useMuatation을 사용한 post와 post의 response를 리코일에 저장 후 loading page로 이동하게끔 구현